### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/Autogen_CodeTutorAgent_Assignment.ipynb
+++ b/Autogen_CodeTutorAgent_Assignment.ipynb
@@ -17,7 +17,7 @@
    "outputs": [],
    "source": [
     "# 🛠️ Step 1: Install required packages\n",
-    "!pip install pyautogen openai --quiet"
+    "!pip install ag2 openai --quiet"
    ]
   },
   {

--- a/MathTutor_Agent.ipynb
+++ b/MathTutor_Agent.ipynb
@@ -50,7 +50,7 @@
       ],
       "source": [
         "# Install necessary package\n",
-        "!pip install pyautogen --quiet"
+        "!pip install ag2 --quiet"
       ]
     },
     {


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!

## Summary by Sourcery

Migrate example notebooks from pyautogen to ag2 by updating installation commands

Enhancements:
- Update pip install commands to use ag2 instead of deprecated pyautogen

Documentation:
- Update Jupyter notebooks to reflect migration from pyautogen to ag2